### PR TITLE
feature/two-way-relationship-retrieval

### DIFF
--- a/UMS.Application/CQRS/Handlers/DeleteUserCommandHandler.cs
+++ b/UMS.Application/CQRS/Handlers/DeleteUserCommandHandler.cs
@@ -35,19 +35,17 @@ public class DeleteUserCommandHandler : IRequestHandler<DeleteUserCommand, UserR
         if (user is null)
             throw new NotFoundException("User with such id does not exist");
 
-        var indirectUserRelationships = await _relationshipRepository.GetAllAsync(r => r.RelatedUserId == request.UserId, cancellationToken);
-
-        if (indirectUserRelationships.Count != 0)
-            await _relationshipRepository.RemoveRangeAsync(indirectUserRelationships, cancellationToken);
-
         var response = user.Adapt<UserResponseModel>();
 
         try
         {
             await _unitOfWork.BeginTransaction(cancellationToken);
        
-            if (user.Relationships is not null)
-                await _relationshipRepository.RemoveRangeAsync(user.Relationships, cancellationToken);
+            if (user.RelatedUsers is not null)
+                await _relationshipRepository.RemoveRangeAsync(user.RelatedUsers, cancellationToken);
+            
+            if (user.RelatedByUsers is not null)
+                await _relationshipRepository.RemoveRangeAsync(user.RelatedByUsers, cancellationToken);
             
             await _userRepository.DeleteAsync(user, cancellationToken);
             await _unitOfWork.CommitTransaction(cancellationToken);

--- a/UMS.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/UMS.Application/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using UMS.Application.Interfaces.Services;
+using UMS.Application.Mappings;
 using UMS.Application.Services;
 
 namespace UMS.Application.Extensions;
@@ -9,6 +10,8 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
+        MappingConfiguration.RegisterMaps();
+        
         services.AddScoped<IUserService, UserService>();
         services.AddMediatR(options => options.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly()));
         

--- a/UMS.Application/Mappings/MappingConfiguration.cs
+++ b/UMS.Application/Mappings/MappingConfiguration.cs
@@ -1,0 +1,43 @@
+﻿using Mapster;
+using UMS.Application.Models.User;
+using UMS.Domain.Entities;
+
+namespace UMS.Application.Mappings;
+
+public static class MappingConfiguration
+{
+    public static void RegisterMaps()
+    {
+        TypeAdapterConfig<User, UserResponseModel>.NewConfig()
+            .Map(dest => dest.Relationships, src => MapRelationships(src));
+
+        TypeAdapterConfig<UserRequestModel, User>.NewConfig()
+            .Map(dest => dest.RelatedUsers, src => src.Relationships);
+    }
+
+    private static List<UserRelationshipDto> MapRelationships(User user)
+    {
+        var relationships = new List<UserRelationshipDto>();
+        
+        if (user.RelatedUsers is not null)
+        {
+            relationships.AddRange(user.RelatedUsers.Select(r => new UserRelationshipDto()
+            {
+                RelatedUserId = r.RelatedUserId,
+                RelationshipType = r.RelationshipType
+            }));
+        }
+        
+        
+        if (user.RelatedByUsers is not null)
+        {
+            relationships.AddRange(user.RelatedByUsers.Select(r => new UserRelationshipDto()
+            {
+                RelatedUserId = r.UserId,
+                RelationshipType = r.RelationshipType
+            }));
+        }
+
+        return relationships;
+    }
+}

--- a/UMS.Domain/Entities/User.cs
+++ b/UMS.Domain/Entities/User.cs
@@ -12,8 +12,9 @@ public class User
     public required string SocialNumber { get; set; }
     public required DateOnly DateOfBirth { get; set; }
     public required int CityId { get; set; }
-    public required City City { get; set; }
+    public City City { get; set; }
     public string? ImageUri { get; set; }
     public required ICollection<PhoneNumber> PhoneNumbers { get; set; }
-    public ICollection<UserRelationship>? Relationships { get; set; }
+    public ICollection<UserRelationship>? RelatedUsers { get; set; }
+    public ICollection<UserRelationship>? RelatedByUsers { get; set; }
 }

--- a/UMS.Infrastructure/Repositories/UserRepository.cs
+++ b/UMS.Infrastructure/Repositories/UserRepository.cs
@@ -29,7 +29,8 @@ public class UserRepository : BaseRepository<User>, IUserRepository
                 || EF.Functions.Like(u.SocialNumber, pattern))
             .Include(u => u.City)
             .Include(u => u.PhoneNumbers)
-            .Include(u => u.Relationships);
+            .Include(u => u.RelatedUsers)
+            .Include(u => u.RelatedByUsers);
             
         var totalCount = await usersQuery.CountAsync(cancellationToken);
         var users = await usersQuery.ToListAsync(cancellationToken);
@@ -50,7 +51,8 @@ public class UserRepository : BaseRepository<User>, IUserRepository
                 u => u.PhoneNumbers.Any(pn => searchModel.PhoneNumbers.Contains(pn.Number)))
             .Include(u => u.City)
             .Include(u => u.PhoneNumbers)
-            .Include(u => u.Relationships);
+            .Include(u => u.RelatedUsers)
+            .Include(u => u.RelatedByUsers);
 
         var totalCount = await usersQuery.CountAsync(cancellationToken);
         var users = await usersQuery.ToListAsync(cancellationToken);
@@ -63,7 +65,8 @@ public class UserRepository : BaseRepository<User>, IUserRepository
         var user = await _dbSet.Where(predicate)
             .Include(u => u.City)
             .Include(u => u.PhoneNumbers)
-            .Include(u => u.Relationships)
+            .Include(u => u.RelatedUsers)
+            .Include(u => u.RelatedByUsers)
             .FirstOrDefaultAsync(cancellationToken);
 
         return user;

--- a/UMS.Persistence/Configurations/UserRelationshipConfiguration.cs
+++ b/UMS.Persistence/Configurations/UserRelationshipConfiguration.cs
@@ -11,12 +11,12 @@ public class UserRelationshipConfiguration : IEntityTypeConfiguration<UserRelati
         builder.HasKey(u => new { u.UserId, u.RelatedUserId });
 
         builder.HasOne(u => u.User)
-            .WithMany(u => u.Relationships)
+            .WithMany(u => u.RelatedUsers)
             .HasForeignKey(u => u.UserId)
             .OnDelete(DeleteBehavior.NoAction);
 
         builder.HasOne(u => u.RelatedUser)
-            .WithMany()
+            .WithMany(u => u.RelatedByUsers)
             .HasForeignKey(u => u.RelatedUserId)
             .OnDelete(DeleteBehavior.NoAction);
 

--- a/UMS.Persistence/Migrations/20250315163609_AddRelatedUsersAndRelatedByUsersNavigationProperties.Designer.cs
+++ b/UMS.Persistence/Migrations/20250315163609_AddRelatedUsersAndRelatedByUsersNavigationProperties.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using UMS.Persistence.Context;
 
@@ -11,9 +12,11 @@ using UMS.Persistence.Context;
 namespace UMS.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250315163609_AddRelatedUsersAndRelatedByUsersNavigationProperties")]
+    partial class AddRelatedUsersAndRelatedByUsersNavigationProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/UMS.Persistence/Migrations/20250315163609_AddRelatedUsersAndRelatedByUsersNavigationProperties.cs
+++ b/UMS.Persistence/Migrations/20250315163609_AddRelatedUsersAndRelatedByUsersNavigationProperties.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace UMS.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRelatedUsersAndRelatedByUsersNavigationProperties : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Summary

### User Relationship Handling
- Updated `User.cs`: Replaced `Relationships` with `RelatedUsers` (direct relationships) and `RelatedByUsers` (indirect relationships)
- Modified `DeleteUserCommandHandler.cs`: Adjusted to handle both direct (`RelatedUsers`) and indirect (`RelatedByUsers`) relationships.

### Mapping Configuration
- Added `MappingConfiguration.cs`: Configured mappings for `User` to `UserResponseModel`, including new direct and indirect properties.
- Updated `ServiceCollectionExtensions.cs`: Registered the new mapping configuration.

### Database Configuration and Migrations
- Updated `UserRelationshipConfiguration.cs`: Reflects `RelatedUsers` and `RelatedByUsers` for direct and indirect links.
- Added migrations `20250315163609_AddRelatedUsersAndRelatedByUsersNavigationProperties`: Schema now supports both relationship types.