### PR TITLE
bugfix/user-update-conflicts

### DIFF
--- a/UMS.API/Controllers/UserController.cs
+++ b/UMS.API/Controllers/UserController.cs
@@ -123,6 +123,9 @@ public class UserController : ControllerBase
     /// \
     /// \
     /// <b>Relationship types can be</b>: Colleague, Friend, Relative, Other
+    /// \
+    /// \
+    /// <b>City IDs can be</b>: 1 (Tbilisi), 2 (Batumi), 3 (Kutaisi)
     /// </remarks>
     /// <param name="user"></param>
     /// <param name="cancellationToken"></param>

--- a/UMS.Domain/Resources/Common/ErrorMessages.cs
+++ b/UMS.Domain/Resources/Common/ErrorMessages.cs
@@ -24,5 +24,6 @@ public static class ErrorMessageNames
     public static readonly string RelationshipExistsAlready = "Relationship_ExistsAlready";
     public static readonly string RelationshipDoesNotExist = "Relationship_DoesNotExist";
     public static readonly string FileDoesNotExist = "File_DoesNotExist";
+    public static readonly string UserAlreadyExistsWithSocialNumberOrPhoneNumber = "User_WithSnOrPnAlreadyExists";
     public static readonly string UnexpectedError = "UnexpectedError";
 }

--- a/UMS.Domain/Resources/ErrorMessages.Designer.cs
+++ b/UMS.Domain/Resources/ErrorMessages.Designer.cs
@@ -195,6 +195,15 @@ namespace UMS.API.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A user with the provided social number or phone number already exists.
+        /// </summary>
+        internal static string User_WithSnOrPnAlreadyExists {
+            get {
+                return ResourceManager.GetString("User_WithSnOrPnAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to One or more users in the relationship are invalid.
         /// </summary>
         internal static string Users_InRelationshipDoNotExist {

--- a/UMS.Domain/Resources/ErrorMessages.ka-GE.Designer.cs
+++ b/UMS.Domain/Resources/ErrorMessages.ka-GE.Designer.cs
@@ -195,6 +195,15 @@ namespace UMS.API.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to მომხმარებელი მოწოდებული სოციალური ნომრით ან ტელეფონის ნომრით უკვე არსებობს.
+        /// </summary>
+        internal static string User_WithSnOrPnAlreadyExists {
+            get {
+                return ResourceManager.GetString("User_WithSnOrPnAlreadyExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ურთიერთობაში მითითებული ერთ-ერთი მომხმარებელი არასწორია.
         /// </summary>
         internal static string Users_InRelationshipDoNotExist {

--- a/UMS.Domain/Resources/ErrorMessages.ka-GE.resx
+++ b/UMS.Domain/Resources/ErrorMessages.ka-GE.resx
@@ -69,4 +69,7 @@
     <data name="UnexpectedError" xml:space="preserve">
         <value>დაფიქსირდა მოულოდნელი შეცდომა სერვერზე, გთხოვთ სცადოთ მოგვიანებით</value>
     </data>
+    <data name="User_WithSnOrPnAlreadyExists" xml:space="preserve">
+        <value>მომხმარებელი მოწოდებული სოციალური ნომრით ან ტელეფონის ნომრით უკვე არსებობს</value>
+    </data>
 </root>

--- a/UMS.Domain/Resources/ErrorMessages.resx
+++ b/UMS.Domain/Resources/ErrorMessages.resx
@@ -69,4 +69,7 @@
     <data name="UnexpectedError" xml:space="preserve">
         <value>Unexpected error happened on the server while trying to serve the response</value>
     </data>
+    <data name="User_WithSnOrPnAlreadyExists" xml:space="preserve">
+        <value>A user with the provided social number or phone number already exists</value>
+    </data>
 </root>


### PR DESCRIPTION
Issue used to stem from the fact that the user was being updated even if the updated social number or phone number was already occupied by someone else.

A fix is introduced in this PR that checks for conflicting users and throws an appropriate exception.