### PR TITLE
bugfix/user-searching

### DIFF
--- a/UMS.API/Infrastructure/Validators/UserDetailedSearchRequestModelValidator.cs
+++ b/UMS.API/Infrastructure/Validators/UserDetailedSearchRequestModelValidator.cs
@@ -1,0 +1,37 @@
+﻿using FluentValidation;
+using Microsoft.Extensions.Localization;
+using UMS.API.Infrastructure.Extensions;
+using UMS.Application.Models.User;
+using UMS.Domain.Resources;
+
+namespace UMS.API.Infrastructure.Validators;
+
+public class UserDetailedSearchRequestModelValidator : AbstractValidator<UserDetailedSearchRequestModel>
+{
+    public UserDetailedSearchRequestModelValidator(IStringLocalizer<ErrorMessages> localizer)
+    {
+        RuleFor(u => u.Firstname)
+            .MinimumLength(1)
+            .MaximumLength(50)
+            .MustBelongToSingleAlphabet()
+            .WithMessage(localizer[ErrorMessageNames.PropertyMustBelongTosingleAlphabet]);
+
+        RuleFor(u => u.Lastname)
+            .MinimumLength(1)
+            .MaximumLength(50)
+            .MustBelongToSingleAlphabet()
+            .WithMessage(localizer[ErrorMessageNames.PropertyMustBelongTosingleAlphabet]);
+
+        RuleFor(u => u.SocialNumber)
+            .MinimumLength(2)
+            .When(u => !string.IsNullOrWhiteSpace(u.SocialNumber))
+            .WithMessage(localizer[ErrorMessageNames.SocialNumberLengthMustBeEleven])
+            .MustBeParsedIntoNumber()
+            .When(u => !string.IsNullOrWhiteSpace(u.SocialNumber))
+            .WithMessage(localizer[ErrorMessageNames.PropertyMustBeNumberError]);
+        
+        RuleForEach(u => u.PhoneNumbers)
+            .MustBeParsedIntoNumber()
+            .WithMessage(localizer[ErrorMessageNames.PropertyMustBeNumberError]);
+    }
+}

--- a/UMS.Infrastructure/Repositories/UserRepository.cs
+++ b/UMS.Infrastructure/Repositories/UserRepository.cs
@@ -19,7 +19,7 @@ public class UserRepository : BaseRepository<User>, IUserRepository
 
     public async Task<(ICollection<User> Users, int TotalCount)> GetUserByQueryLike(string query, int page, int pageSize, CancellationToken cancellationToken)
     {
-        var pattern = $"{query}";
+        var pattern = $"%{query}%";
         var offset = (page - 1) * pageSize;
 
         var usersQuery = _dbSet.Where(u =>


### PR DESCRIPTION
The searching functionalities had two flaws:

1. The quick search didn't use the `% %` pattern, therefore the SQL LIKE wasn't being utilized fully to the needs of business requirements.
2. The detailed search wasn't validating the data.

These issues were fixed in this PR by introducing a validator for detailed search and modifying the pattern for the LIKE constraint